### PR TITLE
Adding Travis CI README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.com/msoe-sse/msoe-sse.github.io.svg?branch=master)](https://travis-ci.com/msoe-sse/msoe-sse.github.io)
 # Setup
 1. You will need Ruby installed on your development machine.  Ruby 2.4 or 2.5 should both work fine.
     - Check version with `ruby -v`


### PR DESCRIPTION
I was able to find this. You can just click on the status image when you navigate to our Travis CI project page and it will give you the link for the status badge.