### PR TITLE
Add page to browse past meeting agendas

### DIFF
--- a/_events/pastMeetings.md
+++ b/_events/pastMeetings.md
@@ -7,7 +7,11 @@ published: true
 
 # Website Past Meetings
 
-Click on the date to see the agenda for that meeting.
+Can't make a website meeting?
+
+Totally spaced and couldn't make it?
+
+That's alright; we've got you covered. Check out the past agendas below, and if you have questions, don't hesitate to message the Webmaster!
 
 * [September 23, 2019](https://docs.google.com/document/d/1OetdVQpwWdKmHECrH-X_EVXF0Ifb2_74LMAfI1Uk3JQ/edit)
 * [September 16, 2019](https://docs.google.com/document/d/17jAWxAh5PkatBtZTUTzU1N0Vb1s0L77K6biyjfEW3PA/edit?usp=sharing)

--- a/_events/pastMeetings.md
+++ b/_events/pastMeetings.md
@@ -1,0 +1,14 @@
+---
+layout: page
+title: Website Past Meetings
+permalink: /events/webmeetings
+published: true
+---
+
+# Website Past Meetings
+
+Click on the date to see the agenda for that meeting.
+
+* [September 23, 2019](https://docs.google.com/document/d/1OetdVQpwWdKmHECrH-X_EVXF0Ifb2_74LMAfI1Uk3JQ/edit)
+* [September 16, 2019](https://docs.google.com/document/d/17jAWxAh5PkatBtZTUTzU1N0Vb1s0L77K6biyjfEW3PA/edit?usp=sharing)
+* [September 9, 2019](https://docs.google.com/presentation/d/1tdt1ggyX892HUHy8bQ4pNSAXVhUAU_uxRMvh8EIPI3w/edit?usp=sharing)

--- a/_includes/main/header.html
+++ b/_includes/main/header.html
@@ -28,6 +28,7 @@
                   <a class="navigation-bar_link_dropdown" href="{{ '/events/points' | prepend: site.baseurl}}">points</a>
                   <a class="navigation-bar_link_dropdown" href="{{ '/events/gamejam' | prepend: site.baseurl }}">game jam</a>
                   <a class="navigation-bar_link_dropdown" href="{{ '/events/lightningtalks' | prepend: site.baseurl }}">lightning talks</a>
+                  <a class="navigation-bar_link_dropdown" href="{{ '/events/webmeetings' | prepend: site.baseurl }}">website past meetings</a>
                 </div>
               </div>
               <a class="navigation-bar_link" href="{{ '/repositories' | prepend: site.baseurl }}">repositories</a>


### PR DESCRIPTION
This is the short-term solution for Issue #96. The page can be accessed from the Events drop-down menu. Until the long-term solution is implemented, the agendas have to be added manually to `_events/pastMeetings.md`.